### PR TITLE
fix: fetch ubuntu.csv from Salsa instead of Launchpad

### DIFF
--- a/src/distro_support/ubuntu.py
+++ b/src/distro_support/ubuntu.py
@@ -3,7 +3,7 @@
 from . import _debian_like_downloader
 
 SUPPORT_INFO_URL = (
-    "https://git.launchpad.net/ubuntu/+source/distro-info-data/plain/ubuntu.csv"
+    "https://salsa.debian.org/debian/distro-info-data/-/raw/main/ubuntu.csv"
 )
 
 


### PR DESCRIPTION
git.launchpad.net has reliability issues causing CI failures. Salsa (salsa.debian.org) is the canonical upstream source for distro-info-data, so this switches the URL there.

Fixes CI failures caused by git.launchpad.net downtime.