### PR TITLE
ci: run tests on Windows and macOS

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,11 +30,12 @@ jobs:
         run: make -k lint
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - name: Check out code


### PR DESCRIPTION
Extends the test matrix to run on `ubuntu-latest`, `macos-latest`, and `windows-latest`, giving 18 jobs total (3 OSes × 6 Python versions).