### PR TITLE
ci: add LXD job to test on various Linux distributions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,3 +49,44 @@ jobs:
         run: make setup-tests
       - name: Test
         run: make test
+
+  test-distros:
+    name: Test (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - almalinux/9
+          - centos/9-Stream
+          - debian/forky
+          - debian/sid
+          - fedora/43
+        include:
+          - distro: almalinux/9
+            setup: dnf install -y make curl
+          - distro: centos/9-Stream
+            setup: dnf install -y make curl
+          - distro: debian/forky
+            setup: apt-get update && apt-get install -y make curl
+          - distro: debian/sid
+            setup: apt-get update && apt-get install -y make curl
+          - distro: fedora/43
+            setup: dnf install -y make curl
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up LXD
+        uses: canonical/setup-lxd@v0.1.1
+      - name: Launch container
+        run: lxc launch images:${{ matrix.distro }} testenv
+      - name: Install dependencies in container
+        run: lxc exec testenv -- ${{ matrix.setup }}
+      - name: Install uv in container
+        run: lxc exec testenv -- sh -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
+      - name: Push source into container
+        run: lxc file push --recursive . testenv/root/distro-support/
+      - name: Set up tests
+        run: lxc exec testenv --cwd /root/distro-support -- sh -c "PATH=/root/.local/bin:$PATH make setup-tests"
+      - name: Run tests
+        run: lxc exec testenv --cwd /root/distro-support -- sh -c "PATH=/root/.local/bin:$PATH make test"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,13 @@ jobs:
           - centos/9-Stream
           - debian/forky
           - debian/sid
+          - devuan/chimaera
+          - devuan/daedalus
+          - devuan/excalibur
           - fedora/43
+          - kali
+          - mint/21.3
+          - mint/zena
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,14 +67,5 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up LXD
         uses: canonical/setup-lxd@v1
-        with:
-          preseed: |
-            networks:
-            - name: lxdbr0
-              type: bridge
-              config:
-                ipv4.address: auto
-                ipv6.address: none
-                dns.nameservers: 8.8.8.8,8.8.4.4
       - name: Run tests in container
         run: make test-lxd LXD_DISTRO=${{ matrix.distro }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Set up LXD
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@v1
       - name: Launch container
         run: lxc launch images:${{ matrix.distro }} testenv
       - name: Install dependencies in container

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,24 +76,5 @@ jobs:
                 ipv4.address: auto
                 ipv6.address: none
                 dns.nameservers: 8.8.8.8,8.8.4.4
-      - name: Launch container
-        run: lxc launch images:${{ matrix.distro }} testenv
-      - name: Install dependencies in container
-        run: |
-          lxc exec testenv -- sh -c "
-            if command -v apt-get > /dev/null 2>&1; then
-              apt-get update && apt-get install -y make curl
-            elif command -v dnf > /dev/null 2>&1; then
-              dnf install -y make curl
-            else
-              echo 'No supported package manager found' && exit 1
-            fi
-          "
-      - name: Install uv in container
-        run: lxc exec testenv -- sh -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
-      - name: Push source into container
-        run: lxc file push --recursive . testenv/root/distro-support/
-      - name: Set up tests
-        run: lxc exec testenv --cwd /root/distro-support -- sh -c "PATH=/root/.local/bin:$PATH make setup-tests"
-      - name: Run tests
-        run: lxc exec testenv --cwd /root/distro-support -- sh -c "PATH=/root/.local/bin:$PATH make test"
+      - name: Run tests in container
+        run: make test-lxd LXD_DISTRO=${{ matrix.distro }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,13 +61,15 @@ jobs:
           - centos/9-Stream
           - debian/forky
           - debian/sid
-          - devuan/chimaera
           - devuan/daedalus
           - devuan/excalibur
           - fedora/43
           - kali
           - mint/21.3
           - mint/zena
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - ubuntu-minimal-daily:26.04
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,15 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up LXD
         uses: canonical/setup-lxd@v1
+        with:
+          preseed: |
+            networks:
+            - name: lxdbr0
+              type: bridge
+              config:
+                ipv4.address: auto
+                ipv6.address: none
+                dns.nameservers: 8.8.8.8,8.8.4.4
       - name: Launch container
         run: lxc launch images:${{ matrix.distro }} testenv
       - name: Install dependencies in container

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,17 +62,6 @@ jobs:
           - debian/forky
           - debian/sid
           - fedora/43
-        include:
-          - distro: almalinux/9
-            setup: dnf install -y make curl
-          - distro: centos/9-Stream
-            setup: dnf install -y make curl
-          - distro: debian/forky
-            setup: apt-get update && apt-get install -y make curl
-          - distro: debian/sid
-            setup: apt-get update && apt-get install -y make curl
-          - distro: fedora/43
-            setup: dnf install -y make curl
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -81,7 +70,16 @@ jobs:
       - name: Launch container
         run: lxc launch images:${{ matrix.distro }} testenv
       - name: Install dependencies in container
-        run: lxc exec testenv -- ${{ matrix.setup }}
+        run: |
+          lxc exec testenv -- sh -c "
+            if command -v apt-get > /dev/null 2>&1; then
+              apt-get update && apt-get install -y make curl
+            elif command -v dnf > /dev/null 2>&1; then
+              dnf install -y make curl
+            else
+              echo 'No supported package manager found' && exit 1
+            fi
+          "
       - name: Install uv in container
         run: lxc exec testenv -- sh -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
       - name: Push source into container

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,23 @@ endif
 .PHONY: update
 update: install-uv
 	uv run tools/update.py
+
+LXD_DISTRO ?= ubuntu/24.04
+LXD_CONTAINER = distro-support-$(subst /,-,$(LXD_DISTRO))
+
+.PHONY: test-lxd
+test-lxd:  ## Run tests in an ephemeral LXD container (set LXD_DISTRO=distro/version)
+	lxc launch --ephemeral images:$(LXD_DISTRO) $(LXD_CONTAINER)
+	trap 'lxc stop $(LXD_CONTAINER) 2>/dev/null || true' EXIT
+	lxc exec $(LXD_CONTAINER) -- sh -c '\
+		if command -v apt-get > /dev/null 2>&1; then \
+			apt-get update && apt-get install -y make curl; \
+		elif command -v dnf > /dev/null 2>&1; then \
+			dnf install -y make curl; \
+		else \
+			echo "No supported package manager found" >&2; exit 1; \
+		fi'
+	lxc file push --recursive . $(LXD_CONTAINER)/root/distro-support/
+	lxc exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
+	lxc exec $(LXD_CONTAINER) --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make setup-tests'
+	lxc exec $(LXD_CONTAINER) --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make test'

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 		$(LXC) start $(LXD_CONTAINER) 2>/dev/null || true
 	else
 		$(LXC) launch images:$(LXD_DISTRO) $(LXD_CONTAINER)
+		$(LXC) exec $(LXD_CONTAINER) -- sh -c 'until test -d /etc; do sleep 1; done; rm -f /etc/resolv.conf && printf "nameserver 8.8.8.8\n" > /etc/resolv.conf'
 		$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
 			if command -v apt-get > /dev/null 2>&1; then \
 				apt-get update && apt-get install -y make curl; \

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ update: install-uv
 LXD_PROJECT ?= distro-support-tests
 LXD_DISTRO ?= debian/bookworm
 LXD_IMAGE = $(if $(findstring :,$(LXD_DISTRO)),$(LXD_DISTRO),images:$(LXD_DISTRO))
-LXD_CONTAINER = distro-support-$(subst :,-,$(subst /,-,$(subst .,-,$(patsubst images:%,%,$(LXD_DISTRO)))))
+LXD_CONTAINER = $(subst :,-,$(subst /,-,$(subst .,-,$(patsubst images:%,%,$(LXD_DISTRO)))))
 LXC = lxc --project $(LXD_PROJECT)
 
 .PHONY: clean-lxd
@@ -95,13 +95,15 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 	$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
 		until grep -q ^nameserver /etc/resolv.conf 2>/dev/null; do sleep 1; done; \
 		if command -v apt-get > /dev/null 2>&1; then \
-			apt-get update && apt-get install -y make curl; \
+			apt-get update && apt-get install -y make curl python3; \
 		elif command -v dnf > /dev/null 2>&1; then \
-			dnf install -y make curl tar; \
+			dnf install -y make curl tar python3; \
+			python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null || dnf install -y python3.11; \
 		else \
 			echo "No supported package manager found" >&2; exit 1; \
 		fi'
 	$(LXC) exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
 	$(LXC) file push --recursive $(PWD) $(LXD_CONTAINER)/root/
-	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 SETUPTOOLS_SCM_PRETEND_VERSION=0.0 setup-tests'
-	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 test'
+	$(LXC) exec $(LXD_CONTAINER) --cwd /root/distro-support -- sh -c 'rm -f .python-version'
+	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --env UV_PYTHON_DOWNLOADS=never --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 SETUPTOOLS_SCM_PRETEND_VERSION=0.0 setup-tests'
+	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --env UV_PYTHON_DOWNLOADS=never --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 test'

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,13 @@ LXD_DISTRO ?= debian/bookworm
 LXD_CONTAINER = distro-support-$(subst /,-,$(subst .,-,$(LXD_DISTRO)))
 LXC = lxc --project $(LXD_PROJECT)
 
-.PHONY: test-lxd
+.PHONY: clean-lxd
+clean-lxd:  ## Delete all LXD test containers and the project
+	lxc project show $(LXD_PROJECT) > /dev/null 2>&1 || exit 0
+	$(LXC) list --format csv -c n | xargs -r -I{} $(LXC) delete --force {}
+	lxc project delete $(LXD_PROJECT)
+
+
 test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 	lxc project show $(LXD_PROJECT) > /dev/null 2>&1 || lxc project create $(LXD_PROJECT) -c features.images=false -c features.profiles=false
 	trap '$(LXC) stop $(LXD_CONTAINER) 2>/dev/null || true' EXIT
@@ -84,17 +90,17 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 		$(LXC) start $(LXD_CONTAINER) 2>/dev/null || true
 	else
 		$(LXC) launch images:$(LXD_DISTRO) $(LXD_CONTAINER)
-		$(LXC) exec $(LXD_CONTAINER) -- sh -c 'until test -d /etc; do sleep 1; done; rm -f /etc/resolv.conf && printf "nameserver 8.8.8.8\n" > /etc/resolv.conf'
-		$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
-			if command -v apt-get > /dev/null 2>&1; then \
-				apt-get update && apt-get install -y make curl; \
-			elif command -v dnf > /dev/null 2>&1; then \
-				dnf install -y make curl; \
-			else \
-				echo "No supported package manager found" >&2; exit 1; \
-			fi'
-		$(LXC) exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
 	fi
+	$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
+		until grep -q ^nameserver /etc/resolv.conf 2>/dev/null; do sleep 1; done; \
+		if command -v apt-get > /dev/null 2>&1; then \
+			apt-get update && apt-get install -y make curl; \
+		elif command -v dnf > /dev/null 2>&1; then \
+			dnf install -y make curl tar; \
+		else \
+			echo "No supported package manager found" >&2; exit 1; \
+		fi'
+	$(LXC) exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
 	$(LXC) file push --recursive $(PWD) $(LXD_CONTAINER)/root/
 	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 SETUPTOOLS_SCM_PRETEND_VERSION=0.0 setup-tests'
 	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 test'

--- a/Makefile
+++ b/Makefile
@@ -71,22 +71,29 @@ endif
 update: install-uv
 	uv run tools/update.py
 
-LXD_DISTRO ?= ubuntu/24.04
-LXD_CONTAINER = distro-support-$(subst /,-,$(LXD_DISTRO))
+LXD_PROJECT ?= distro-support-tests
+LXD_DISTRO ?= debian/bookworm
+LXD_CONTAINER = distro-support-$(subst /,-,$(subst .,-,$(LXD_DISTRO)))
+LXC = lxc --project $(LXD_PROJECT)
 
 .PHONY: test-lxd
-test-lxd:  ## Run tests in an ephemeral LXD container (set LXD_DISTRO=distro/version)
-	lxc launch --ephemeral images:$(LXD_DISTRO) $(LXD_CONTAINER)
-	trap 'lxc stop $(LXD_CONTAINER) 2>/dev/null || true' EXIT
-	lxc exec $(LXD_CONTAINER) -- sh -c '\
-		if command -v apt-get > /dev/null 2>&1; then \
-			apt-get update && apt-get install -y make curl; \
-		elif command -v dnf > /dev/null 2>&1; then \
-			dnf install -y make curl; \
-		else \
-			echo "No supported package manager found" >&2; exit 1; \
-		fi'
-	lxc file push --recursive . $(LXD_CONTAINER)/root/distro-support/
-	lxc exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
-	lxc exec $(LXD_CONTAINER) --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make setup-tests'
-	lxc exec $(LXD_CONTAINER) --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make test'
+test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
+	lxc project show $(LXD_PROJECT) > /dev/null 2>&1 || lxc project create $(LXD_PROJECT) -c features.images=false -c features.profiles=false
+	trap '$(LXC) stop $(LXD_CONTAINER) 2>/dev/null || true' EXIT
+	if $(LXC) info $(LXD_CONTAINER) > /dev/null 2>&1; then
+		$(LXC) start $(LXD_CONTAINER) 2>/dev/null || true
+	else
+		$(LXC) launch images:$(LXD_DISTRO) $(LXD_CONTAINER)
+		$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
+			if command -v apt-get > /dev/null 2>&1; then \
+				apt-get update && apt-get install -y make curl; \
+			elif command -v dnf > /dev/null 2>&1; then \
+				dnf install -y make curl; \
+			else \
+				echo "No supported package manager found" >&2; exit 1; \
+			fi'
+		$(LXC) exec $(LXD_CONTAINER) -- sh -c 'curl -LsSf https://astral.sh/uv/install.sh | env HOME=/root sh'
+	fi
+	$(LXC) file push --recursive $(PWD) $(LXD_CONTAINER)/root/
+	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 SETUPTOOLS_SCM_PRETEND_VERSION=0.0 setup-tests'
+	$(LXC) exec $(LXD_CONTAINER) --env DEBIAN_FRONTEND=noninteractive --cwd /root/distro-support -- sh -c 'PATH=/root/.local/bin:$$PATH make CI=1 test'

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ update: install-uv
 
 LXD_PROJECT ?= distro-support-tests
 LXD_DISTRO ?= debian/bookworm
-LXD_CONTAINER = distro-support-$(subst /,-,$(subst .,-,$(LXD_DISTRO)))
+LXD_IMAGE = $(if $(findstring :,$(LXD_DISTRO)),$(LXD_DISTRO),images:$(LXD_DISTRO))
+LXD_CONTAINER = distro-support-$(subst :,-,$(subst /,-,$(subst .,-,$(patsubst images:%,%,$(LXD_DISTRO)))))
 LXC = lxc --project $(LXD_PROJECT)
 
 .PHONY: clean-lxd
@@ -89,7 +90,7 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 	if $(LXC) info $(LXD_CONTAINER) > /dev/null 2>&1; then
 		$(LXC) start $(LXD_CONTAINER) 2>/dev/null || true
 	else
-		$(LXC) launch images:$(LXD_DISTRO) $(LXD_CONTAINER)
+		$(LXC) launch $(LXD_IMAGE) $(LXD_CONTAINER)
 	fi
 	$(LXC) exec $(LXD_CONTAINER) -- sh -c '\
 		until grep -q ^nameserver /etc/resolv.conf 2>/dev/null; do sleep 1; done; \


### PR DESCRIPTION
## Summary

Adds an LXD-based CI job that runs the test suite inside real Linux distribution containers.

## Distros tested

- **Debian**: forky, sid
- **Devuan**: daedalus, excalibur
- **AlmaLinux**: 9
- **CentOS**: 9-Stream
- **Fedora**: 43
- **Kali**: rolling
- **Mint**: 21.3, zena
- **Ubuntu**: 22.04, 24.04, 26.04 (daily minimal)

## Makefile targets

- `make test-lxd [LXD_DISTRO=remote:distro/version]` — run tests in a container (reused between runs, supports explicit LXD remotes)
- `make clean-lxd` — delete all test containers and the project

## Notes

- Containers live in the `distro-support-tests` LXD project (auto-created)
- Uses distro native Python; installs `python3.11` on RHEL 9-family where system Python is 3.9
- `UV_PYTHON_DOWNLOADS=never` + removes `.python-version` so uv uses the distro Python
- DNS preseed (`8.8.8.8`) fixes resolution in RPM-based containers on GitHub Actions
- Devuan chimaera removed (Python 3.9, below minimum)