### PR TITLE
ci: add Alpine 3.23 to LXD test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
+          - alpine/3.23
           - almalinux/9
           - centos/9-Stream
           - debian/forky

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,6 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
+          - alpine/3.21
+          - alpine/3.22
           - alpine/3.23
           - almalinux/9
           - centos/9-Stream

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,6 +60,7 @@ jobs:
           - alpine/3.21
           - alpine/3.22
           - alpine/3.23
+          - alpine/edge
           - almalinux/9
           - centos/9-Stream
           - debian/forky

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 			dnf install -y make curl tar python3; \
 			python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null || dnf install -y python3.11; \
 		elif command -v apk > /dev/null 2>&1; then \
-			apk add make curl python3; \
+			apk add --no-cache make curl python3; \
 		else \
 			echo "No supported package manager found" >&2; exit 1; \
 		fi'

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 		elif command -v dnf > /dev/null 2>&1; then \
 			dnf install -y make curl tar python3; \
 			python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null || dnf install -y python3.11; \
+		elif command -v apk > /dev/null 2>&1; then \
+			apk add make curl python3; \
 		else \
 			echo "No supported package manager found" >&2; exit 1; \
 		fi'


### PR DESCRIPTION
Adds Alpine Linux to the LXD distro test matrix.

## Changes
- Added `apk` support to the `test-lxd` Makefile target (alongside existing apt-get and dnf support)
- Added all available Alpine versions to the `test-distros` job in `pr.yaml`:
  - `alpine/3.21`
  - `alpine/3.22`
  - `alpine/3.23`
  - `alpine/edge`

## Tested
All 4 Alpine variants pass all 29 tests locally (Python 3.12).