### PR TITLE
ci: run LXD distro tests on arm64 runners

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,6 +77,11 @@ jobs:
           - ubuntu:22.04
           - ubuntu:24.04
           - ubuntu-minimal-daily:26.04
+        exclude:
+          - runner: ubuntu-24.04-arm
+            distro: mint/21.3
+          - runner: ubuntu-24.04-arm
+            distro: mint/zena
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,11 +51,14 @@ jobs:
         run: make test
 
   test-distros:
-    name: Test (${{ matrix.distro }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.distro }}, ${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         distro:
           - alpine/3.21
           - alpine/3.22

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,6 +87,29 @@ jobs:
           if [[ "${{ matrix.runner }}" != *arm* ]]; then
             distros+=(mint/21.3 mint/zena)
           fi
+          passed=()
+          failed=()
           for distro in "${distros[@]}"; do
-            make test-lxd LXD_DISTRO="$distro"
+            echo "::group::$distro"
+            if make test-lxd LXD_DISTRO="$distro"; then
+              passed+=("$distro")
+            else
+              failed+=("$distro")
+            fi
+            echo "::endgroup::"
           done
+
+          {
+            echo "## Distro test results (${{ matrix.runner }})"
+            echo ""
+            echo "### ✅ Passed (${#passed[@]})"
+            for d in "${passed[@]}"; do echo "- $d"; done
+            echo ""
+            if [[ ${#failed[@]} -gt 0 ]]; then
+              echo "### ❌ Failed (${#failed[@]})"
+              for d in "${failed[@]}"; do echo "- $d"; done
+              echo ""
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [[ ${#failed[@]} -eq 0 ]]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
         run: make test
 
   test-distros:
-    name: Test (${{ matrix.distro }}, ${{ matrix.runner }})
+    name: LXD Test (${{ matrix.distro }}, ${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
         run: make test
 
   test-distros:
-    name: LXD Test (${{ matrix.distro }}, ${{ matrix.runner }})
+    name: Test distros (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -59,33 +59,34 @@ jobs:
         runner:
           - ubuntu-latest
           - ubuntu-24.04-arm
-        distro:
-          - alpine/3.21
-          - alpine/3.22
-          - alpine/3.23
-          - alpine/edge
-          - almalinux/9
-          - centos/9-Stream
-          - debian/forky
-          - debian/sid
-          - devuan/daedalus
-          - devuan/excalibur
-          - fedora/43
-          - kali
-          - mint/21.3
-          - mint/zena
-          - ubuntu:22.04
-          - ubuntu:24.04
-          - ubuntu-minimal-daily:26.04
-        exclude:
-          - runner: ubuntu-24.04-arm
-            distro: mint/21.3
-          - runner: ubuntu-24.04-arm
-            distro: mint/zena
     steps:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Set up LXD
         uses: canonical/setup-lxd@v1
-      - name: Run tests in container
-        run: make test-lxd LXD_DISTRO=${{ matrix.distro }}
+      - name: Run tests in containers
+        run: |
+          distros=(
+            alpine/3.21
+            alpine/3.22
+            alpine/3.23
+            alpine/edge
+            almalinux/9
+            centos/9-Stream
+            debian/forky
+            debian/sid
+            devuan/daedalus
+            devuan/excalibur
+            fedora/43
+            kali
+            ubuntu:22.04
+            ubuntu:24.04
+            ubuntu-minimal-daily:26.04
+          )
+          # Mint images are not available for arm64
+          if [[ "${{ matrix.runner }}" != *arm* ]]; then
+            distros+=(mint/21.3 mint/zena)
+          fi
+          for distro in "${distros[@]}"; do
+            make test-lxd LXD_DISTRO="$distro"
+          done

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,6 +64,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up LXD
         uses: canonical/setup-lxd@v1
+      - name: Set up LXD project
+        run: |
+          lxc project show distro-support-tests > /dev/null 2>&1 || \
+            lxc project create distro-support-tests -c features.images=false -c features.profiles=false
       - name: Run tests in containers
         run: |
           distros=(
@@ -87,16 +91,30 @@ jobs:
           if [[ "${{ matrix.runner }}" != *arm* ]]; then
             distros+=(mint/21.3 mint/zena)
           fi
+
+          # Launch all distros in parallel, capturing output to per-distro log files
+          declare -A pids logs
+          for distro in "${distros[@]}"; do
+            log=$(mktemp)
+            logs[$distro]=$log
+            make test-lxd LXD_DISTRO="$distro" >"$log" 2>&1 &
+            pids[$distro]=$!
+          done
+
+          # Collect results in order, replaying logs with collapsible groups
           passed=()
           failed=()
           for distro in "${distros[@]}"; do
             echo "::group::$distro"
-            if make test-lxd LXD_DISTRO="$distro"; then
+            cat "${logs[$distro]}"
+            if wait "${pids[$distro]}"; then
               passed+=("$distro")
             else
               failed+=("$distro")
+              echo "::error::$distro failed"
             fi
             echo "::endgroup::"
+            rm "${logs[$distro]}"
           done
 
           {


### PR DESCRIPTION
Adds arm64 coverage to the containerised distro tests and improves CI ergonomics.

## Changes

### arm64 support
- Added `ubuntu-24.04-arm` as a second runner alongside `ubuntu-latest`
- Linux Mint is excluded on arm64 (no arm64 images available on the `images:` remote)

### Restructured job layout
- Replaced one-job-per-distro matrix with two jobs (one per arch), each running all distros in a loop
- Reduces job count from ~32 to 2

### Parallel execution
- All distro containers are launched simultaneously so downloads and setup overlap
- Output is captured to per-distro log files and replayed sequentially after each job completes
- A dedicated 'Set up LXD project' step pre-creates the LXC project before the parallel jobs start, avoiding a race condition

### Output improvements
- Each distro's output is wrapped in `::group::` / `::endgroup::` for collapsible sections in the Actions UI
- Failed distros emit a `::error::` annotation so they're highlighted even when collapsed
- A Markdown step summary (written to `$GITHUB_STEP_SUMMARY`) shows ✅/❌ per distro after the run