### PR TITLE
ci: add archlinux, debian/12, openSUSE, and Rocky Linux to test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,13 +76,18 @@ jobs:
             alpine/3.23
             alpine/edge
             almalinux/9
+            archlinux
             centos/9-Stream
+            debian/12
             debian/forky
             debian/sid
             devuan/daedalus
             devuan/excalibur
             fedora/43
             kali
+            opensuse/15.6
+            opensuse/tumbleweed
+            rockylinux/9
             ubuntu:22.04
             ubuntu:24.04
             ubuntu-minimal-daily:26.04

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else ifneq ($(shell which snap),)
 	sudo snap install --beta astral-ty
 	sudo snap alias astral-ty.ty ty
 else ifneq ($(shell which uv),)
-	uv tool install ty
+	uv tool install --prerelease=allow ty || true
 endif
 
 .PHONY: update
@@ -99,6 +99,11 @@ test-lxd:  ## Run tests in an LXD container (set LXD_DISTRO=distro/version)
 		elif command -v dnf > /dev/null 2>&1; then \
 			dnf install -y make curl tar python3; \
 			python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null || dnf install -y python3.11; \
+		elif command -v zypper > /dev/null 2>&1; then \
+			zypper --non-interactive install make curl python3; \
+			python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)" 2>/dev/null || zypper --non-interactive install python310; \
+		elif command -v pacman > /dev/null 2>&1; then \
+			pacman -Sy --noconfirm make curl python3; \
 		elif command -v apk > /dev/null 2>&1; then \
 			apk add --no-cache make curl python3; \
 		else \


### PR DESCRIPTION
Adds 5 new distros to the LXD test matrix, along with Makefile fixes needed to support them.

## New distros
- `archlinux` (rolling)
- `debian/12` (Bookworm, Python 3.11)
- `opensuse/tumbleweed` (rolling)
- `opensuse/15.6` (Leap, Python 3.10 installed conditionally)
- `rockylinux/9` (RHEL 9 clone, Python 3.11 installed conditionally)

## Makefile changes
- Added `zypper` support (openSUSE)
- Added `pacman` support (Arch Linux)
- openSUSE Leap 15.6 ships Python 3.6 by default — added conditional `python310` install, matching the existing pattern for AlmaLinux/CentOS 9
- Made `install-ty` fail gracefully (`|| true`) since `ty` doesn't support Python < 3.12; tests still run fine without it

## Tested
All 5 distros pass all 29 tests locally.