### PR TITLE
chore: add Copilot instructions and collections config

### DIFF
--- a/.github/.copilot-collections.yaml
+++ b/.github/.copilot-collections.yaml
@@ -1,0 +1,7 @@
+# https://github.com/canonical/copilot-collections
+
+copilot:
+  version: v0.12.0
+  collections:
+    - core
+    - common-python

--- a/.github/instructions/core-directive.instructions.md
+++ b/.github/instructions/core-directive.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "**"
+description: "Prevent Copilot from wreaking havoc across your codebase, keeping it under control."
+---
+
+## Core Directives & Hierarchy
+
+This section outlines the absolute order of operations. These rules have the highest priority and must not be violated.
+
+1.  **Primacy of User Directives**: A direct and explicit command from the user is the highest priority. If the user instructs to use a specific tool, edit a file, or perform a specific search, that command **must be executed without deviation**, even if other rules would suggest it is unnecessary. All other instructions are subordinate to a direct user order.
+2.  **Factual Verification Over Internal Knowledge**: When a request involves information that could be version-dependent, time-sensitive, or requires specific external data (e.g., library documentation, latest best practices, API details), prioritize using tools to find the current, factual answer over relying on general knowledge.
+3.  **Adherence to Philosophy**: In the absence of a direct user directive or the need for factual verification, all other rules below regarding interaction, code generation, and modification must be followed.
+
+## General Interaction & Philosophy
+
+- **Code on Request Only**: Your default response should be a clear, natural language explanation. Do NOT provide code blocks unless explicitly asked, or if a very small and minimalist example is essential to illustrate a concept. Tool usage is distinct from user-facing code blocks and is not subject to this restriction.
+- **Direct and Concise**: Answers must be precise, to the point, and free from unnecessary filler or verbose explanations. Get straight to the solution without "beating around the bush".
+- **Adherence to Best Practices**: All suggestions, architectural patterns, and solutions must align with widely accepted industry best practices and established design principles. Avoid experimental, obscure, or overly "creative" approaches. Stick to what is proven and reliable.
+- **Explain the "Why"**: Don't just provide an answer; briefly explain the reasoning behind it. Why is this the standard approach? What specific problem does this pattern solve? This context is more valuable than the solution itself.
+
+## Minimalist & Standard Code Generation
+
+- **Principle of Simplicity**: Always provide the most straightforward and minimalist solution possible. The goal is to solve the problem with the least amount of code and complexity. Avoid premature optimization or over-engineering.
+- **Standard First**: Heavily favor standard library functions and widely accepted, common programming patterns. Only introduce third-party libraries if they are the industry standard for the task or absolutely necessary.
+- **Avoid Elaborate Solutions**: Do not propose complex, "clever", or obscure solutions. Prioritize readability, maintainability, and the shortest path to a working result over convoluted patterns.
+- **Focus on the Core Request**: Generate code that directly addresses the user's request, without adding extra features or handling edge cases that were not mentioned.
+
+## Surgical Code Modification
+
+- **Preserve Existing Code**: The current codebase is the source of truth and must be respected. Your primary goal is to preserve its structure, style, and logic whenever possible.
+- **Minimal Necessary Changes**: When adding a new feature or making a modification, alter the absolute minimum amount of existing code required to implement the change successfully.
+- **Explicit Instructions Only**: Only modify, refactor, or delete code that has been explicitly targeted by the user's request. Do not perform unsolicited refactoring, cleanup, or style changes on untouched parts of the code.
+- **Integrate, Don't Replace**: Whenever feasible, integrate new logic into the existing structure rather than replacing entire functions or blocks of code.
+
+## Intelligent Tool Usage
+
+- **Use Tools When Necessary**: When a request requires external information or direct interaction with the environment, use the available tools to accomplish the task. Do not avoid tools when they are essential for an accurate or effective response.
+- **Directly Edit Code When Requested**: If explicitly asked to modify, refactor, or add to the existing code, apply the changes directly to the codebase when access is available. Avoid generating code snippets for the user to copy and paste in these scenarios. The default should be direct, surgical modification as instructed.
+- **Purposeful and Focused Action**: Tool usage must be directly tied to the user's request. Do not perform unrelated searches or modifications. Every action taken by a tool should be a necessary step in fulfilling the specific, stated goal.
+- **Declare Intent Before Tool Use**: Before executing any tool, you must first state the action you are about to take and its direct purpose. This statement must be concise and immediately precede the tool call.

--- a/.github/instructions/distro-support.instructions.md
+++ b/.github/instructions/distro-support.instructions.md
@@ -1,0 +1,134 @@
+---
+description: "Project-specific guidelines for distro-support, a Python library for querying Linux distribution support dates."
+applyTo: "**"
+---
+
+# distro-support Development Guidelines
+
+`distro-support` is a Python library that provides support date information for Linux
+distributions. It ships JSON data files for each supported distro and exposes a simple
+`get_support_range()` API, plus optional online downloaders that fetch live data from
+upstream sources.
+
+## Project Structure
+
+```
+src/distro_support/
+    __init__.py                  # Public API: get_support_range()
+    _distro.py                   # Core dataclasses: SupportRange, DistroInfo
+    errors.py                    # Exceptions: UnknownDistributionError, etc.
+    <distro>.py                  # Per-distro module (e.g. debian.py, ubuntu.py)
+    <distro>.json                # Bundled support data (e.g. debian.json)
+    _debian_like_downloader.py   # Shared downloader for Debian-family distros
+    _rhel_downloader.py          # Downloader for RHEL-family distros
+tests/
+    test_distro.py
+    test_get_support_range.py
+    test_debian_like_downloader.py
+    test_alpine_downloader.py
+tools/
+    update.py                    # Regenerates all JSON data files from upstream
+```
+
+## Tooling
+
+- **Package manager**: `uv` — use `uv run <cmd>` inside the project, never bare `pip`
+- **Test runner**: `pytest` — run with `uv run pytest` or `make test`
+- **Linter/formatter**: `ruff` — run with `make lint` or `uv run ruff check`
+- **Type checker**: `ty` (astral-ty snap) — run with `make lint`
+- **Pre-commit**: configured in `.pre-commit-config.yaml`; CI enforces it
+- **Build**: `make` wraps common tasks; `make help` lists all targets
+- **LXD testing**: `make test-lxd LXD_DISTRO=<distro>/<version>` runs the test suite
+  inside an LXD container to verify cross-distro compatibility
+
+## Core Data Model
+
+`SupportRange` (in `_distro.py`) is the central dataclass:
+
+```python
+@dataclasses.dataclass(kw_only=True, slots=True)
+class SupportRange:
+    distribution: str
+    version: str
+    begin_support: Optional[datetime.date]
+    end_support: Optional[datetime.date]
+    begin_dev: Optional[datetime.date] = None
+    end_extended_support: Optional[datetime.date] = None
+```
+
+- All date fields are `Optional[datetime.date]` — a `None` means the date is unknown
+- `end_extended_support` represents ESM/LTS extended support (e.g. Ubuntu Pro)
+- `from_json(data: dict[str, str | None])` is the standard constructor from JSON
+
+## JSON Data Files
+
+Each distro's bundled data is a JSON object keyed by version string:
+
+```json
+{
+    "12": {
+        "eol": "2026-06-30",
+        "release": "2021-08-14"
+    },
+    "": {
+        "release": null,
+        "eol": null
+    }
+}
+```
+
+- Keys are version strings; an empty string `""` represents the rolling/sid release
+- Date values are ISO 8601 strings (`"YYYY-MM-DD"`) or `null`
+- Keep versions in **ascending numeric order**; keep keys within each version object
+  in a consistent order (typically `release` before `eol`/`eol-*`)
+- The `tools/update.py` script regenerates these files from upstream; run it after
+  adding a new distro or refreshing data, then commit the updated JSON
+
+## Adding a New Distribution
+
+1. Create `src/distro_support/<distro>.json` with version data
+2. Create `src/distro_support/<distro>.py` that exposes `get_distro_info()` (returning
+   a `dict[str, SupportRange]`) — either use a bundled JSON file or a downloader
+3. Register the new module so `get_support_range()` finds it
+4. Add the distro to the CI matrix in `.github/workflows/pr.yaml` (both `x86-64` and
+   `arm64` lists where applicable; Linux Mint is x86-64 only)
+5. Add `make test-lxd LXD_DISTRO=<distro>/<version>` verification locally before PR
+
+## Downloaders
+
+Downloaders live in `_<family>_downloader.py` and follow this pattern:
+
+- Accept an optional `requests.Session` (or similar) for testability
+- Raise `RuntimeError` for unexpected HTTP status codes (not 200)
+- Return `dict[str, SupportRange]`
+- Use `(row.get("field") or None)` when reading CSV/API fields that may be empty
+  strings — empty string is falsy but not `None`, and `datetime.date.fromisoformat("")`
+  raises `ValueError`
+
+## Testing Conventions
+
+- Use `pytest` with `freezegun` for date-sensitive tests
+- Mock HTTP calls with `unittest.mock.patch` on `requests.get` (or the session method)
+- Test files mirror source files: `test_<module>.py`
+- Each downloader should have tests for: normal data, empty optional fields, HTTP errors
+- Keep test parametrization flat and readable; avoid deeply nested fixtures
+
+## Type Annotations
+
+- All public functions and methods must be fully annotated
+- Use `Optional[X]` (not `X | None`) for compatibility with Python 3.10
+- Use `typing_extensions` for features not yet in the stdlib minimum (currently 3.10)
+- `ty` (astral-ty) is the primary type checker; it is stricter than mypy on narrowing —
+  assign to a local variable before an `is None` check rather than checking
+  `data.get("key") is None` directly
+
+## CI Matrix
+
+The `test-distros` GitHub Actions job tests against 22 distros across two runners:
+
+- **x86-64** (`ubuntu-latest`): 20 distros including Linux Mint
+- **arm64** (`ubuntu-24.04-arm`): 18 distros (Mint excluded)
+
+LXD containers are launched in parallel; the `test-lxd` Make target handles network
+readiness (default route + DNS), package installation with retry, and file transfer via
+`tar` pipe (excluding `.venv`, `.git`, `__pycache__`).

--- a/.github/instructions/distro-support.instructions.md
+++ b/.github/instructions/distro-support.instructions.md
@@ -58,7 +58,7 @@ class SupportRange:
 
 - All date fields are `Optional[datetime.date]` — a `None` means the date is unknown
 - `end_extended_support` represents ESM/LTS extended support (e.g. Ubuntu Pro)
-- `from_json(data: dict[str, Optional[str]])` is the standard constructor from JSON
+- `from_json(data: dict[str, str | None])` is the standard constructor from JSON
 
 ## JSON Data Files
 
@@ -116,7 +116,8 @@ Downloaders live in `_<family>_downloader.py` and follow this pattern:
 ## Type Annotations
 
 - All public functions and methods must be fully annotated
-- Use `Optional[X]` (not `X | None`) for consistency with the existing codebase
+- Use `X | None` (not `Optional[X]`) — `Optional` appears in older code from when the
+  project supported Python 3.8, but `X | None` is preferred going forward
 - Use `typing_extensions` for features not yet in the stdlib minimum (currently 3.10)
 - `ty` (astral-ty) is the primary type checker; it is stricter than mypy on narrowing —
   assign to a local variable before an `is None` check rather than checking

--- a/.github/instructions/distro-support.instructions.md
+++ b/.github/instructions/distro-support.instructions.md
@@ -58,7 +58,7 @@ class SupportRange:
 
 - All date fields are `Optional[datetime.date]` — a `None` means the date is unknown
 - `end_extended_support` represents ESM/LTS extended support (e.g. Ubuntu Pro)
-- `from_json(data: dict[str, str | None])` is the standard constructor from JSON
+- `from_json(data: dict[str, Optional[str]])` is the standard constructor from JSON
 
 ## JSON Data Files
 
@@ -116,7 +116,7 @@ Downloaders live in `_<family>_downloader.py` and follow this pattern:
 ## Type Annotations
 
 - All public functions and methods must be fully annotated
-- Use `Optional[X]` (not `X | None`) for compatibility with Python 3.10
+- Use `Optional[X]` (not `X | None`) for consistency with the existing codebase
 - Use `typing_extensions` for features not yet in the stdlib minimum (currently 3.10)
 - `ty` (astral-ty) is the primary type checker; it is stricter than mypy on narrowing —
   assign to a local variable before an `is None` check rather than checking

--- a/.github/instructions/instructions.instructions.md
+++ b/.github/instructions/instructions.instructions.md
@@ -1,0 +1,264 @@
+---
+description: "Guidelines for creating high-quality custom instruction files for GitHub Copilot"
+applyTo: "**/*.instructions.md"
+---
+
+# Custom Instructions File Guidelines
+
+Instructions for creating effective and maintainable custom instruction files that guide GitHub Copilot in generating domain-specific code and following project conventions.
+
+## Project Context
+
+- Target audience: Developers and GitHub Copilot working with domain-specific code
+- File format: Markdown with YAML frontmatter
+- File naming convention: lowercase with hyphens (e.g., `react-best-practices.instructions.md`)
+- Location: `.github/instructions/` directory
+- Purpose: Provide context-aware guidance for code generation, review, and documentation
+
+## Required Frontmatter
+
+Every instruction file must include YAML frontmatter with the following fields:
+
+```yaml
+---
+description: "Brief description of the instruction purpose and scope"
+applyTo: "glob pattern for target files (e.g., **/*.ts, **/*.py)"
+---
+```
+
+### Frontmatter Guidelines
+
+- **description**: Single-quoted string, 1-500 characters, clearly stating the purpose
+- **applyTo**: Glob pattern(s) specifying which files these instructions apply to
+    - Single pattern: `'**/*.ts'`
+    - Multiple patterns: `'**/*.ts, **/*.tsx, **/*.js'`
+    - Specific files: `'src/**/*.py'`
+    - All files: `'**'`
+
+## File Structure
+
+A well-structured instruction file should include the following sections:
+
+### 1. Title and Overview
+
+- Clear, descriptive title using `#` heading
+- Brief introduction explaining the purpose and scope
+- Optional: Project context section with key technologies and versions
+
+### 2. Core Sections
+
+Organize content into logical sections based on the domain:
+
+- **General Instructions**: High-level guidelines and principles
+- **Best Practices**: Recommended patterns and approaches
+- **Code Standards**: Naming conventions, formatting, style rules
+- **Architecture/Structure**: Project organization and design patterns
+- **Common Patterns**: Frequently used implementations
+- **Security**: Security considerations (if applicable)
+- **Performance**: Optimization guidelines (if applicable)
+- **Testing**: Testing standards and approaches (if applicable)
+
+### 3. Examples and Code Snippets
+
+Provide concrete examples with clear labels:
+
+```markdown
+### Good Example
+
+\`\`\`language
+// Recommended approach
+code example here
+\`\`\`
+
+### Bad Example
+
+\`\`\`language
+// Avoid this pattern
+code example here
+\`\`\`
+```
+
+### 4. Validation and Verification (Optional but Recommended)
+
+- Build commands to verify code
+- Linting and formatting tools
+- Testing requirements
+- Verification steps
+
+## Content Guidelines
+
+### Writing Style
+
+- Use clear, concise language
+- Write in imperative mood ("Use", "Implement", "Avoid")
+- Be specific and actionable
+- Avoid ambiguous terms like "should", "might", "possibly"
+- Use bullet points and lists for readability
+- Keep sections focused and scannable
+
+### Best Practices
+
+- **Be Specific**: Provide concrete examples rather than abstract concepts
+- **Show Why**: Explain the reasoning behind recommendations when it adds value
+- **Use Tables**: For comparing options, listing rules, or showing patterns
+- **Include Examples**: Real code snippets are more effective than descriptions
+- **Stay Current**: Reference current versions and best practices
+- **Link Resources**: Include official documentation and authoritative sources
+
+### Common Patterns to Include
+
+1. **Naming Conventions**: How to name variables, functions, classes, files
+2. **Code Organization**: File structure, module organization, import order
+3. **Error Handling**: Preferred error handling patterns
+4. **Dependencies**: How to manage and document dependencies
+5. **Comments and Documentation**: When and how to document code
+6. **Version Information**: Target language/framework versions
+
+## Patterns to Follow
+
+### Bullet Points and Lists
+
+```markdown
+## Security Best Practices
+
+- Always validate user input before processing
+- Use parameterized queries to prevent SQL injection
+- Store secrets in environment variables, never in code
+- Implement proper authentication and authorization
+- Enable HTTPS for all production endpoints
+```
+
+### Tables for Structured Information
+
+```markdown
+## Common Issues
+
+| Issue            | Solution            | Example                       |
+| ---------------- | ------------------- | ----------------------------- |
+| Magic numbers    | Use named constants | `const MAX_RETRIES = 3`       |
+| Deep nesting     | Extract functions   | Refactor nested if statements |
+| Hardcoded values | Use configuration   | Store API URLs in config      |
+```
+
+### Code Comparison
+
+```markdown
+### Good Example - Using TypeScript interfaces
+
+\`\`\`typescript
+interface User {
+id: string;
+name: string;
+email: string;
+}
+
+function getUser(id: string): User {
+// Implementation
+}
+\`\`\`
+
+### Bad Example - Using any type
+
+\`\`\`typescript
+function getUser(id: any): any {
+// Loses type safety
+}
+\`\`\`
+```
+
+### Conditional Guidance
+
+```markdown
+## Framework Selection
+
+- **For small projects**: Use Minimal API approach
+- **For large projects**: Use controller-based architecture with clear separation
+- **For microservices**: Consider domain-driven design patterns
+```
+
+## Patterns to Avoid
+
+- **Overly verbose explanations**: Keep it concise and scannable
+- **Outdated information**: Always reference current versions and practices
+- **Ambiguous guidelines**: Be specific about what to do or avoid
+- **Missing examples**: Abstract rules without concrete code examples
+- **Contradictory advice**: Ensure consistency throughout the file
+- **Copy-paste from documentation**: Add value by distilling and contextualizing
+
+## Testing Your Instructions
+
+Before finalizing instruction files:
+
+1. **Test with Copilot**: Try the instructions with actual prompts in VS Code
+2. **Verify Examples**: Ensure code examples are correct and run without errors
+3. **Check Glob Patterns**: Confirm `applyTo` patterns match intended files
+
+## Example Structure
+
+Here's a minimal example structure for a new instruction file:
+
+```markdown
+---
+description: "Brief description of purpose"
+applyTo: "**/*.ext"
+---
+
+# Technology Name Development
+
+Brief introduction and context.
+
+## General Instructions
+
+- High-level guideline 1
+- High-level guideline 2
+
+## Best Practices
+
+- Specific practice 1
+- Specific practice 2
+
+## Code Standards
+
+### Naming Conventions
+
+- Rule 1
+- Rule 2
+
+### File Organization
+
+- Structure 1
+- Structure 2
+
+## Common Patterns
+
+### Pattern 1
+
+Description and example
+
+\`\`\`language
+code example
+\`\`\`
+
+### Pattern 2
+
+Description and example
+
+## Validation
+
+- Build command: `command to verify`
+- Linting: `command to lint`
+- Testing: `command to test`
+```
+
+## Maintenance
+
+- Review instructions when dependencies or frameworks are updated
+- Update examples to reflect current best practices
+- Remove outdated patterns or deprecated features
+- Add new patterns as they emerge in the community
+- Keep glob patterns accurate as project structure evolves
+
+## Additional Resources
+
+- [Custom Instructions Documentation](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
+- [Awesome Copilot Instructions](https://github.com/github/awesome-copilot/tree/main/instructions)

--- a/.github/instructions/python-code-commenting.instructions.md
+++ b/.github/instructions/python-code-commenting.instructions.md
@@ -1,0 +1,181 @@
+---
+description: "Guidelines for GitHub Copilot to write comments to achieve self-explanatory code with fewer comments. Examples are in Python but it should work on any language that has comments."
+applyTo: "**"
+---
+
+# Self-explanatory Code Commenting Instructions
+
+## Core Principle
+
+**Write code that speaks for itself. Comment only when necessary to explain WHY, not WHAT.**
+We do not need comments most of the time.
+
+## Commenting Guidelines
+
+### ❌ AVOID These Comment Types
+
+**Obvious Comments**
+
+```python
+# Bad: States the obvious
+counter = 0  # Initialize counter to zero
+counter += 1  # Increment counter by one
+```
+
+**Redundant Comments**
+
+```python
+# Bad: Comment repeats the code
+def get_user_name():
+    return user.name  # Return the user's name
+```
+
+**Outdated Comments**
+
+```python
+# Bad: Comment doesn't match the code
+# Calculate tax at 5% rate
+tax = price * 0.08  # Actually 8%
+```
+
+### ✅ WRITE These Comment Types
+
+**Complex Business Logic**
+
+```python
+# Good: Explains WHY this specific calculation
+# Apply progressive tax brackets: 10% up to 10k, 20% above
+tax = calculate_progressive_tax(income, [0.10, 0.20], [10_000])
+```
+
+**Non-obvious Algorithms**
+
+```python
+# Good: Explains the algorithm choice
+# Using Floyd–Warshall for all-pairs shortest paths
+# because we need distances between all nodes
+for k in range(vertices):
+    for i in range(vertices):
+        for j in range(vertices):
+            # ... implementation
+            pass
+```
+
+**Regex Patterns**
+
+```python
+# Good: Explains what the regex matches
+# Match email format: username@domain.extension
+import re
+email_pattern = re.compile(r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+```
+
+**API Constraints or Gotchas**
+
+```python
+# Good: Explains external constraint
+# GitHub API rate limit: 5000 requests/hour for authenticated users
+await rate_limiter.wait()
+response = await http_client.get(github_api_url)
+```
+
+## Decision Framework
+
+Before writing a comment, ask:
+
+1. **Is the code self-explanatory?** → No comment needed
+2. **Would a better variable/function name eliminate the need?** → Refactor instead
+3. **Does this explain WHY, not WHAT?** → Good comment
+4. **Will this help future maintainers?** → Good comment
+
+## Special Cases for Comments
+
+### Public APIs
+
+```python
+def calculate_compound_interest(principal: float, rate: float, time: float, compound_frequency: int = 1) -> float:
+    """
+    Calculate compound interest using the standard formula.
+
+    Args:
+        principal (float): Initial amount invested.
+        rate (float): Annual interest rate (as decimal, e.g., 0.05 for 5%).
+        time (float): Time period in years.
+        compound_frequency (int, optional): How many times per year interest compounds (default: 1).
+
+    Returns:
+        float: Final amount after compound interest.
+    """
+    # ... implementation
+    pass
+```
+
+### Configuration and Constants
+
+```python
+# Good: Explains the source or reasoning
+MAX_RETRIES = 3  # Based on network reliability studies
+API_TIMEOUT = 5.0  # AWS Lambda timeout is 15s, leaving buffer (seconds)
+```
+
+### Annotations
+
+```python
+# TODO: Replace with proper user authentication after security review
+# FIXME: Memory leak in production - investigate connection pooling
+# HACK: Workaround for bug in library v2.1.0 - remove after upgrade
+# NOTE: This implementation assumes UTC timezone for all calculations
+# WARNING: This function mutates the input list instead of returning a copy
+# PERF: Consider caching this result if called frequently in a hot path
+# SECURITY: Validate input to prevent SQL injection before using in query
+# BUG: Edge case failure when list is empty - needs investigation
+# REFACTOR: Extract this logic into separate utility function for reusability
+# DEPRECATED: Use new_api_function() instead - this will be removed in v3.0
+```
+
+## Anti-Patterns to Avoid
+
+### Dead Code Comments
+
+```python
+# Bad: Don't comment out code
+# def old_function():
+#     ...
+def new_function():
+    ...
+```
+
+### Changelog Comments
+
+```python
+# Bad: Don't maintain history in comments
+# Modified by John on 2023-01-15
+# Fixed bug reported by Sarah on 2023-02-03
+def process_data():
+    # ... implementation
+    pass
+```
+
+### Divider Comments
+
+```python
+# Bad: Don't use decorative comments
+# =====================================
+# UTILITY FUNCTIONS
+# =====================================
+```
+
+## Quality Checklist
+
+Before committing, ensure your comments:
+
+- [ ] Explain WHY, not WHAT
+- [ ] Are grammatically correct and clear
+- [ ] Will remain accurate as code evolves
+- [ ] Add genuine value to code understanding
+- [ ] Are placed appropriately (above the code they describe)
+- [ ] Use proper spelling and professional language
+
+## Summary
+
+Remember: **The best comment is the one you don't need to write because the code is self-documenting.**


### PR DESCRIPTION
Adds GitHub Copilot custom instructions following the pattern established in [canonical/copilot-collections](https://github.com/canonical/copilot-collections) and [canonical/imagecraft#327](https://github.com/canonical/imagecraft/pull/327).

## Files

### From [canonical/copilot-collections](https://github.com/canonical/copilot-collections) @ v0.12.0

Sourced from the `core` and `common-python` collections:

- **`core-directive.instructions.md`** (`core`): Core interaction rules — primacy of user directives, minimalist code generation, surgical modification, purposeful tool use
- **`instructions.instructions.md`** (`core`): Guidelines for writing instruction files (applies to `**/*.instructions.md`)
- **`python-code-commenting.instructions.md`** (`common-python`): When and how to comment Python code — comment the *why*, not the *what*

### Custom

- **`distro-support.instructions.md`**: Project-specific guidance covering:
  - Project structure and module layout
  - Tooling (`uv`, `pytest`, `ruff`, `ty`, `make`, LXD testing)
  - `SupportRange` data model and JSON file conventions (key ordering, `null` vs empty string)
  - How to add a new distribution (JSON + module + CI matrix)
  - Downloader patterns (`(row.get("field") or None)`, HTTP error handling)
  - Type annotation rules (Python 3.10 compat, `ty` narrowing quirks)
  - CI matrix structure (22 distros across x86-64 and arm64)